### PR TITLE
Prevent integer overflow in binary search

### DIFF
--- a/src_py/AIList.c
+++ b/src_py/AIList.c
@@ -35,7 +35,7 @@ uint32_t bSearch(gdata_t* As, uint32_t idxS, uint32_t idxE, uint32_t qe)
     else if(As[tL].start >= qe)
         return -1;
     while(tL<tR-1){
-        tM = (tL+tR)/2; 
+        tM = tL + (tR - tL)/2; 
         if(As[tM].start >= qe)
             tR = tM-1;
         else


### PR DESCRIPTION
Current `bSearch` implementation will result in integer overflow because it adds `(tL + tR)` to produce `tM = (tL + tR)/2`. This tiny PR fixes it.
Read more about this bug on [Google AI blog](https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html)  
Thank you for this implementation and your paper!